### PR TITLE
tenant switcher width

### DIFF
--- a/forge/src/components/LeftSidebar/TenantSwitcher.tsx
+++ b/forge/src/components/LeftSidebar/TenantSwitcher.tsx
@@ -32,7 +32,7 @@ export function TenantSwitcher(props: TenantSwitcherProps) {
     <div class="w-full relative inline-block text-left">
       {/* DialogRoot must be outside the dropdown menu so it's not unrendered when the menu is closed */}
       <DialogRoot>
-        <DropdownMenu controller={controller}>
+        <DropdownMenu controller={controller} sameWidth>
           <DropdownMenuTrigger class="mt-1 inline-flex w-full justify-between rounded-md bg-brand-secondary text-white px-4 py-2 text-sm font-medium shadow-sm hover:bg-brand-tertiary focus:outline-none focus:ring-2 focus:ring-white disabled:opacity-80 disabled:cursor-not-allowed">
             {/* // TODO: Tooltip when truncated */}
             <span class="truncate">{props.activeTenant.name}</span>


### PR DESCRIPTION
#17 
> Tenant switch dropdown menu is a different width than trigger button

kobalte yet again the goat
<img width="770" alt="image" src="https://github.com/oscartbeaumont/forge/assets/14191578/75012e1c-048b-4960-b2c9-bd3ccf724578">
